### PR TITLE
Update Xcode version requirement instruction in BuildingTheExamples.md

### DIFF
--- a/Sources/Playdate/Documentation.docc/BuildingTheExamples.md
+++ b/Sources/Playdate/Documentation.docc/BuildingTheExamples.md
@@ -75,6 +75,9 @@ After a successful build, the `.build/release` directory will contain object fil
 
 ### Build with Xcode
 
+> IMPORTANT:
+> Xcode 15.3+ is required to run the examples in Xcode.
+
 Open an example's `Package.swift` with Xcode via the command line or the Xcode graphical interface.
 
 ```console
@@ -88,4 +91,5 @@ Select your Swift nightly toolchain from the Xcode > Toolchains menu item.
 
 Select the Run icon in the toolbar or press Cmd+R on your keyboard to start a build. This will first build the example for the host machine using `xcbuild`. After a successful initial build, Xcode will automatically build again with `make` then open the Simulator with the newly built game.
 
-> Note: Learn more about [Xcode](https://developer.apple.com/xcode/)
+> Note:
+> Learn more about [Xcode](https://developer.apple.com/xcode/)


### PR DESCRIPTION
![image](https://github.com/apple/swift-playdate-examples/assets/43724855/6a45846d-27bc-421b-bfe8-cbc2ac29179b)

![image](https://github.com/apple/swift-playdate-examples/assets/43724855/b99cdc73-bd42-4a34-af0a-22055cf4ddfa)

Opening the example projects with Xcode 15.3- will have issue running it.

1. Add explicit description that Xcode 15.3+ is required
2. Or we can modify the `Examples/SwiftBreak/.swiftpm/xcode/xcshareddata/xcschemes/SwiftBreak.xcscheme` file to make it compatible with older Xcode version.