### PR TITLE
Update Package.swift to remove Foundation import

### DIFF
--- a/Examples/Life/Package.swift
+++ b/Examples/Life/Package.swift
@@ -1,11 +1,10 @@
 // swift-tools-version: 5.9
 
-import Foundation
 import PackageDescription
 
 let gccIncludePrefix =
   "/usr/local/playdate/gcc-arm-none-eabi-9-2019-q4-major/lib/gcc/arm-none-eabi/9.2.1"
-guard let home = ProcessInfo().environment["HOME"] else {
+guard let home = Context.environment["HOME"] else {
   fatalError("could not determine home directory")
 }
 

--- a/Examples/SwiftBreak/Package.swift
+++ b/Examples/SwiftBreak/Package.swift
@@ -1,11 +1,10 @@
 // swift-tools-version: 5.9
 
-import Foundation
 import PackageDescription
 
 let gccIncludePrefix =
   "/usr/local/playdate/gcc-arm-none-eabi-9-2019-q4-major/lib/gcc/arm-none-eabi/9.2.1"
-guard let home = ProcessInfo().environment["HOME"] else {
+guard let home = Context.environment["HOME"] else {
   fatalError("could not determine home directory")
 }
 

--- a/Examples/Template/Package.swift
+++ b/Examples/Template/Package.swift
@@ -1,11 +1,10 @@
 // swift-tools-version: 5.9
 
-import Foundation
 import PackageDescription
 
 let gccIncludePrefix =
   "/usr/local/playdate/gcc-arm-none-eabi-9-2019-q4-major/lib/gcc/arm-none-eabi/9.2.1"
-guard let home = ProcessInfo().environment["HOME"] else {
+guard let home = Context.environment["HOME"] else {
   fatalError("could not determine home directory")
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,10 @@
 // swift-tools-version: 5.9
 
-import Foundation
 import PackageDescription
 
 let gccIncludePrefix =
   "/usr/local/playdate/gcc-arm-none-eabi-9-2019-q4-major/lib/gcc/arm-none-eabi/9.2.1"
-guard let home = ProcessInfo.processInfo.environment["HOME"] else {
+guard let home = Context.environment["HOME"] else {
   fatalError("could not determine home directory")
 }
 


### PR DESCRIPTION
We use prefer to use `PackageDescription.Context.environment` instead of using `ProcessInfo().environment` directly.

> Actually they are the same currently.

https://github.com/apple/swift-package-manager/blob/b49a22787a5873f8f67e5de48ae3ba7499bfb9d8/Sources/PackageDescription/Context.swift#L38-L41

https://github.com/apple/swift-package-manager/blob/b49a22787a5873f8f67e5de48ae3ba7499bfb9d8/Sources/PackageDescription/ContextModel.swift#L1

https://github.com/apple/swift-package-manager/blob/b49a22787a5873f8f67e5de48ae3ba7499bfb9d8/Sources/PackageLoading/ContextModel.swift#L23-L25
