### PR TITLE
Updates game Template to mimic SwiftBreak.

### DIFF
--- a/Examples/Template/Makefile
+++ b/Examples/Template/Makefile
@@ -1,6 +1,6 @@
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
 PRODUCT := {{Game name}}.pdx
-SRC += $(REPO_ROOT)/Sources/CPlaydate/posix_memalign.c
+SRC += $(REPO_ROOT)/Sources/CPlaydate/playdate.c
 include $(REPO_ROOT)/Examples/swift.mk
 
 # MARK: - Build Playdate Overlay Swift Module

--- a/Examples/Template/Sources/Entry.swift
+++ b/Examples/Template/Sources/Entry.swift
@@ -1,6 +1,12 @@
+#if swift(>=6.0)
+public import Playdate
+#else
 import Playdate
+#endif
 
-var game: Game!
+// Opt out of static concurrency checking. We know that the playdate runtime is
+// single threaded and this global will never be concurrently accessed.
+nonisolated(unsafe) var game = Game()
 
 @_cdecl("update")
 func update(pointer: UnsafeMutableRawPointer?) -> Int32 {
@@ -14,9 +20,8 @@ public func eventHandler(
   event: PDSystemEvent,
   arg: UInt32
 ) -> Int32 {
-  playdate = pointer.bindMemory(to: PlaydateAPI.self, capacity: 1)
+  initializePlaydateAPI(with: pointer)
   if event == .initialize {
-    game = Game()
     System.setUpdateCallback(update: update, userdata: nil)
   }
   return 0


### PR DESCRIPTION
Before, new games created from the Template directory would fail to compile. When fixed, would fail to link
This PR borrows the patterns from Swift Break.


## The Errors

After copying the Template directory and updating the appropriate `{{Game Name}}` placeholders and the `pdxinfo` file contents, builds would fail with this error:
```
make: *** No rule to make target `/Users/markd/Projects/thirdparty/swift-playdate-examples/Sources/CPlaydate/posix_memalign.c', needed by `build//Users/markd/Projects/thirdparty/swift-playdate-examples/Sources/CPlaydate/posix_memalign.o'.  Stop.
```

Taking out the `SRC += $(REPO_ROOT)/Sources/CPlaydate/posix_memalign.c` line from the makefile results in a link error not finding the `playdate` symbol:
```
device_lib.o:(.text.$s10device_lib12eventHandler7pointer0C03args5Int32VSvSg_So13PDSystemEventas6UInt32VtF+0x24): undefined reference to `playdate'
```

so use `SRC += $(REPO_ROOT)/Sources/CPlaydate/playdate.c`  instead.

Then, while building, get this error:

```
Sources/Entry.swift:3:5: error: var 'game' is not concurrency-safe because it is non-isolated global shared mutable state
 1 │ import Playdate
 2 │ 
 3 │ var game: Game!
   │     ├─ error: var 'game' is not concurrency-safe because it is non-isolated global shared mutable state
   │     ╰─ note: isolate 'game' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'
 4 │ 
 5 │ @_cdecl("update")
```
Entry.swift changed for SwiftBreak to initialize the game in-place rather than waiting until `.initialize` time in the Playdate lifecycle.
