### PR TITLE
Make Sprite: ~Copyable

### DIFF
--- a/Examples/SwiftBreak/Sources/FixedArray.swift
+++ b/Examples/SwiftBreak/Sources/FixedArray.swift
@@ -1,0 +1,35 @@
+struct FixedArray<Element: ~Copyable>: ~Copyable {
+    let count: Int
+    private let _buffer: UnsafeMutablePointer<Element>
+
+    init(count: Int, first: consuming Element, rest: (borrowing Element)->Element) {
+        precondition(count > 0)
+        self.count = count
+        _buffer = .allocate(capacity: count)
+        for i in 1..<count {
+            (_buffer + i).initialize(to: rest(first))
+        }
+        _buffer.initialize(to: first)
+    }
+
+    deinit {
+        _buffer.deinitialize(count: count)
+        _buffer.deallocate()
+    }
+}
+
+extension FixedArray where Element: ~Copyable {
+  func forEach(_ body: (borrowing Element)->Void) {
+    for i in 0..<self.count {
+      body((self._buffer + i).pointee)
+    }
+  }
+
+  func enumerated(_ body: (Int, borrowing Element)->Void) {
+    var i = 0
+    self.forEach {
+      body(i, $0)
+      i += 1
+    }
+  }
+}

--- a/Examples/SwiftBreak/Sources/Game.swift
+++ b/Examples/SwiftBreak/Sources/Game.swift
@@ -13,7 +13,7 @@ struct Sprites: ~Copyable {
   var ball: Sprite
   var paddle: Sprite
   var gameOver: Sprite
-  var bricks: [Sprite]
+  var bricks: FixedArray<Sprite>
 }
 
 struct ActiveGame {
@@ -45,7 +45,7 @@ struct Game: ~Copyable {
         ball: .ball(),
         paddle: .paddle(),
         gameOver: .gameOver(),
-        bricks: (0..<40).map { index in index == 0 ? brick : brick.copy() })
+        bricks: .init(count: 40, first: brick) { $0.copy() })
     splash.addSprite()
     Sprite.drawSprites()
     self.state = .loading
@@ -125,7 +125,7 @@ extension Game {
 
     let brickWidth = 40
     let brickHeight = 24
-    for (index, brick) in sprites.bricks.enumerated() {
+    sprites.bricks.enumerated { index, brick in
       let x = (index % 10)
       let y = (index / 10)
       brick.moveTo(
@@ -154,7 +154,7 @@ extension Game {
   mutating func gameOver() {
     self.sprites.ball.removeSprite()
     self.sprites.paddle.removeSprite()
-    for brick in sprites.bricks {
+    self.sprites.bricks.forEach { brick in
       brick.removeSprite()
     }
     self.sprites.gameOver.moveTo(

--- a/Examples/SwiftBreak/Sources/Game.swift
+++ b/Examples/SwiftBreak/Sources/Game.swift
@@ -7,7 +7,7 @@ enum State {
   case gameOver
 }
 
-struct Sprites {
+struct Sprites: ~Copyable {
   var splash: Sprite
   var paused: Sprite
   var ball: Sprite
@@ -22,7 +22,7 @@ struct ActiveGame {
   var bricksRemaining: Int
 }
 
-struct Game {
+struct Game: ~Copyable {
   var state: State
   var sprites: Sprites
 

--- a/Examples/SwiftBreak/Sources/Game.swift
+++ b/Examples/SwiftBreak/Sources/Game.swift
@@ -38,6 +38,7 @@ struct Game: ~Copyable {
     // Start in loading state with 4 x 10 bricks.
     let brick = Sprite.brick()
     let splash = Sprite.splash()
+    splash.addSprite()
     self.sprites =
       .init(
         splash: splash,
@@ -46,7 +47,6 @@ struct Game: ~Copyable {
         paddle: .paddle(),
         gameOver: .gameOver(),
         bricks: .init(count: 40, first: brick) { $0.copy() })
-    splash.addSprite()
     Sprite.drawSprites()
     self.state = .loading
   }

--- a/Examples/swift.mk
+++ b/Examples/swift.mk
@@ -41,6 +41,7 @@ SWIFT_FLAGS := \
 	$(addprefix -Xcc , $(C_FLAGS)) \
 	-Osize \
 	-wmo -enable-experimental-feature Embedded \
+	-enable-experimental-feature NoncopyableGenerics \
 	-Xfrontend -disable-stack-protector \
 	-Xfrontend -function-sections \
 	-swift-version 6 \


### PR DESCRIPTION
Now that support for `UnsafeMutablePointer<Pointee: ~Copyable>` has landed in the standard library (gated under the `-enable-experimental-feature NoncopyableGenerics`), we can use it to simplify the `Sprite` type.

This converts the `Sprite` wrapper for the Playdate SDK from an enum+class to track ownership to a non-copyable struct that can have a `deinit` and needs no reference counting. It also adds a very minimal array type to hold the bricks (since the regular `Array` type cannot yet hold non-copyable types).

This drops binary size by about 14%. Half of this is from simplifying the sprite type, and half is from the simpler array type.