### PR TITLE
Refactor Life implementation for better perf

### DIFF
--- a/Examples/Life/Makefile
+++ b/Examples/Life/Makefile
@@ -1,14 +1,22 @@
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
 PRODUCT := Life.pdx
+SRC += $(REPO_ROOT)/Sources/CPlaydate/playdate.c
 include $(REPO_ROOT)/Examples/swift.mk
 
-# MARK: - Build Game Swift Object
-build/device_lib.o: Sources/*.swift
-	$(SWIFT_EXEC) $(SWIFT_FLAGS) $(SWIFT_FLAGS_DEVICE) -c $^ -o $@
-$(OBJDIR)/pdex.elf: build/device_lib.o
-OBJS += build/device_lib.o
+# MARK: - Build Playdate Overlay Swift Module
+build/Modules/playdate_device.o: $(REPO_ROOT)/Sources/Playdate/*.swift
+	$(SWIFT_EXEC) $(SWIFT_FLAGS) $(SWIFT_FLAGS_DEVICE) -c $^ -emit-module -o $@
 
-build/simulator_lib.o: Sources/*.swift
+build/Modules/playdate_simulator.o: $(REPO_ROOT)/Sources/Playdate/*.swift
+	$(SWIFT_EXEC) $(SWIFT_FLAGS) $(SWIFT_FLAGS_SIMULATOR) -c $^ -emit-module -o $@
+
+# MARK: - Build Game Swift Object
+build/game_device.o: Sources/*.swift | build/Modules/playdate_device.o
+	$(SWIFT_EXEC) $(SWIFT_FLAGS) $(SWIFT_FLAGS_DEVICE) -c $^ -o $@
+$(OBJDIR)/pdex.elf: build/game_device.o
+OBJS += build/game_device.o
+
+build/game_simulator.o: Sources/*.swift | build/Modules/playdate_simulator.o
 	$(SWIFT_EXEC) $(SWIFT_FLAGS) $(SWIFT_FLAGS_SIMULATOR) -c $^ -o $@
-$(OBJDIR)/pdex.${DYLIB_EXT}: build/simulator_lib.o
-SIMCOMPILER += build/simulator_lib.o
+$(OBJDIR)/pdex.${DYLIB_EXT}: build/game_simulator.o
+SIMCOMPILER += build/game_simulator.o

--- a/Examples/Life/Package.swift
+++ b/Examples/Life/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
     .target(
       name: "Life",
       dependencies: [
-        .product(name: "CPlaydate", package: "swift-playdate-examples")
+        .product(name: "Playdate", package: "swift-playdate-examples")
       ],
       swiftSettings: swiftSettingsSimulator)
   ],

--- a/Examples/swift.mk
+++ b/Examples/swift.mk
@@ -39,7 +39,7 @@ C_FLAGS := \
 
 SWIFT_FLAGS := \
 	$(addprefix -Xcc , $(C_FLAGS)) \
-	-Osize \
+	-O \
 	-wmo -enable-experimental-feature Embedded \
 	-Xfrontend -disable-stack-protector \
 	-Xfrontend -function-sections \

--- a/Sources/Playdate/Graphics.swift
+++ b/Sources/Playdate/Graphics.swift
@@ -217,3 +217,28 @@ extension Graphics {
     graphicsAPI.fillPolygon.unsafelyUnwrapped(nPoints, points, color, fillRule)
   }
 }
+
+// MARK: - Miscellaneous
+extension Graphics {
+  /// Returns the current display frame buffer. Rows are 32-bit aligned, so the
+  /// row stride is 52 bytes, with the extra 2 bytes per row ignored. Bytes are
+  /// MSB-ordered; i.e., the pixel in column 0 is the 0x80 bit of the first byte
+  /// of the row.
+  public static func getFrame() -> UnsafeMutablePointer<UInt8>? {
+    graphicsAPI.getFrame.unsafelyUnwrapped()
+  }
+
+  /// Returns the raw bits in the display buffer, the last completed frame.
+  public static func getDisplayFrame() -> UnsafeMutablePointer<UInt8>? {
+    graphicsAPI.getDisplayFrame.unsafelyUnwrapped()
+  }
+
+  /// After updating pixels in the buffer returned by getFrame(), you must tell
+  /// the graphics system which rows were updated. This function marks a
+  /// contiguous range of rows as updated (e.g., `markUpdatedRows(0,LCD_ROWS-1`)
+  /// tells the system to update the entire display). Both “start” and “end” are
+  /// included in the range.
+  public static func markUpdatedRows(start: Int32, end: Int32) {
+    graphicsAPI.markUpdatedRows.unsafelyUnwrapped(start, end)
+  }
+}


### PR DESCRIPTION
Restructures the Conways Game of Life swift implementation to make the hotloop faster. This version matches the C versions performance while using nicer wrapper types.

Using -Osize causes the binary to be smaller than the C version at the cost of perf. This commit changes the build to use -O instead, which causes the binary size to match C, but also matches the performance of the C version.

<img width="744" alt="Screenshot 2024-03-22 at 11 50 13 AM" src="https://github.com/apple/swift-playdate-examples/assets/9739930/d8a7cf71-df4d-4b7d-9ed5-d6078692928f">