### PR TITLE
Debug simulator non embedded

### DIFF
--- a/Examples/SwiftBreak/Package.swift
+++ b/Examples/SwiftBreak/Package.swift
@@ -12,10 +12,11 @@ let swiftSettingsSimulator: [SwiftSetting] = [
   .enableExperimentalFeature("Embedded"),
   .enableExperimentalFeature("NoncopyableGenerics"),
   .unsafeFlags([
+    "-g", "-Onone",
     "-Xfrontend", "-disable-objc-interop",
     "-Xfrontend", "-disable-stack-protector",
     "-Xfrontend", "-function-sections",
-    "-Xfrontend", "-gline-tables-only",
+    // "-Xfrontend", "-gline-tables-only",
     "-Xcc", "-DTARGET_EXTENSION",
     "-Xcc", "-I", "-Xcc", "\(gccIncludePrefix)/include",
     "-Xcc", "-I", "-Xcc", "\(gccIncludePrefix)/include-fixed",
@@ -27,17 +28,20 @@ let swiftSettingsSimulator: [SwiftSetting] = [
 let package = Package(
   name: "SwiftBreak",
   products: [
-    .library(name: "SwiftBreak", targets: ["SwiftBreak"])
+    .library(name: "SwiftBreak", type: .static, targets: ["SwiftBreak"]),
   ],
   dependencies: [
     .package(path: "../..")
   ],
   targets: [
     .target(
-      name: "SwiftBreak",
-      dependencies: [
-        .product(name: "Playdate", package: "swift-playdate-examples")
-      ],
-      swiftSettings: swiftSettingsSimulator)
+        name: "SwiftBreak",
+        dependencies: [
+            .product(name: "Playdate", package: "swift-playdate-examples"),
+            .product(name: "CPlaydate", package: "swift-playdate-examples"),
+        ],
+        path: "Sources",
+        swiftSettings: swiftSettingsSimulator
+    )
   ],
   swiftLanguageVersions: [.version("6"), .v5])

--- a/Examples/SwiftBreak/Package.swift
+++ b/Examples/SwiftBreak/Package.swift
@@ -9,13 +9,11 @@ guard let home = Context.environment["HOME"] else {
 }
 
 let swiftSettingsSimulator: [SwiftSetting] = [
-  .enableExperimentalFeature("Embedded"),
   .enableExperimentalFeature("NoncopyableGenerics"),
   .unsafeFlags([
-    "-g", "-Onone",
     "-Xfrontend", "-disable-objc-interop",
-    "-Xfrontend", "-disable-stack-protector",
-    "-Xfrontend", "-function-sections",
+    // "-Xfrontend", "-disable-stack-protector",
+    // "-Xfrontend", "-function-sections",
     // "-Xfrontend", "-gline-tables-only",
     "-Xcc", "-DTARGET_EXTENSION",
     "-Xcc", "-I", "-Xcc", "\(gccIncludePrefix)/include",
@@ -28,7 +26,7 @@ let swiftSettingsSimulator: [SwiftSetting] = [
 let package = Package(
   name: "SwiftBreak",
   products: [
-    .library(name: "SwiftBreak", type: .static, targets: ["SwiftBreak"]),
+    .library(name: "SwiftBreak", type: .dynamic, targets: ["SwiftBreak"]),
   ],
   dependencies: [
     .package(path: "../..")
@@ -38,7 +36,6 @@ let package = Package(
         name: "SwiftBreak",
         dependencies: [
             .product(name: "Playdate", package: "swift-playdate-examples"),
-            .product(name: "CPlaydate", package: "swift-playdate-examples"),
         ],
         path: "Sources",
         swiftSettings: swiftSettingsSimulator

--- a/Examples/SwiftBreak/Sources/Entry.swift
+++ b/Examples/SwiftBreak/Sources/Entry.swift
@@ -10,7 +10,9 @@ nonisolated(unsafe) var game = Game()
 
 @_cdecl("update")
 func update(pointer: UnsafeMutableRawPointer?) -> Int32 {
-  game.updateGame()
+  if game.updateGame() {
+    Sprite.updateAndDrawSprites()
+  }
   return 1
 }
 

--- a/Examples/SwiftBreak/Sources/Game.swift
+++ b/Examples/SwiftBreak/Sources/Game.swift
@@ -53,9 +53,10 @@ struct Game: ~Copyable {
 }
 
 extension Game {
-  mutating func updateGame() {
+  mutating func updateGame() -> Bool {
     let pushed = System.buttonState.pushed
-    switch self.state {
+    let state = self.state
+    switch state {
     case .loading:
       if pushed == .a {
         self.startNewGame()
@@ -89,8 +90,8 @@ extension Game {
         self.startNewGame()
       }
     }
-
-    Sprite.updateAndDrawSprites()
+      
+    return true
   }
 
   mutating func startNewGame() {

--- a/Examples/SwiftBreak/buildit
+++ b/Examples/SwiftBreak/buildit
@@ -1,9 +1,0 @@
-#!/bin/sh
-# swift build -Xcc -c -Xswiftc -g -Xswiftc -Onone -c release --verbose
-swift build -c release --verbose
-clang -g -nostdlib -Wl,-exported_symbol,_eventHandlerShim -Wl,-exported_symbol,_eventHandler \
--dynamiclib -rdynamic -lm \
-.build/release/libPlaydate.a .build/release/libSwiftBreak.a .build/release/libCPlaydate.a \
--o build/pdex.dylib
-cp build/pdex.dylib Source
-${HOME}/Developer/PlaydateSDK/bin/pdc Source SwiftBreak.pdx

--- a/Examples/SwiftBreak/buildit
+++ b/Examples/SwiftBreak/buildit
@@ -1,0 +1,9 @@
+#!/bin/sh
+# swift build -Xcc -c -Xswiftc -g -Xswiftc -Onone -c release --verbose
+swift build -c release --verbose
+clang -g -nostdlib -Wl,-exported_symbol,_eventHandlerShim -Wl,-exported_symbol,_eventHandler \
+-dynamiclib -rdynamic -lm \
+.build/release/libPlaydate.a .build/release/libSwiftBreak.a .build/release/libCPlaydate.a \
+-o build/pdex.dylib
+cp build/pdex.dylib Source
+${HOME}/Developer/PlaydateSDK/bin/pdc Source SwiftBreak.pdx

--- a/Examples/SwiftBreak/simbuild
+++ b/Examples/SwiftBreak/simbuild
@@ -1,0 +1,4 @@
+#!/bin/sh
+swift build
+cp .build/arm64-apple-macosx/debug/libSwiftBreak.dylib Source/pdex.dylib
+${HOME}/Developer/PlaydateSDK/bin/pdc Source SwiftBreak.pdx

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ guard let home = Context.environment["HOME"] else {
 }
 
 let swiftSettingsSimulator: [SwiftSetting] = [
-  .enableExperimentalFeature("Embedded"),
+  // .enableExperimentalFeature("Embedded"),
   .unsafeFlags([
     "-g", "-Onone",
     "-Xfrontend", "-Onone",

--- a/Package.swift
+++ b/Package.swift
@@ -11,10 +11,12 @@ guard let home = Context.environment["HOME"] else {
 let swiftSettingsSimulator: [SwiftSetting] = [
   .enableExperimentalFeature("Embedded"),
   .unsafeFlags([
+    "-g", "-Onone",
+    "-Xfrontend", "-Onone",
     "-Xfrontend", "-disable-objc-interop",
     "-Xfrontend", "-disable-stack-protector",
     "-Xfrontend", "-function-sections",
-    "-Xfrontend", "-gline-tables-only",
+    // "-Xfrontend", "-gline-tables-only",
     "-Xcc", "-DTARGET_EXTENSION",
     "-Xcc", "-I", "-Xcc", "\(gccIncludePrefix)/include",
     "-Xcc", "-I", "-Xcc", "\(gccIncludePrefix)/include-fixed",
@@ -26,6 +28,7 @@ let swiftSettingsSimulator: [SwiftSetting] = [
 let cSettingsSimulator: [CSetting] = [
   .unsafeFlags([
     "-DTARGET_EXTENSION",
+    "-nostdlib",
     "-I", "\(gccIncludePrefix)/include",
     "-I", "\(gccIncludePrefix)/include-fixed",
     "-I", "\(gccIncludePrefix)/../../../../arm-none-eabi/include",
@@ -36,8 +39,8 @@ let cSettingsSimulator: [CSetting] = [
 let package = Package(
   name: "swift-playdate-examples",
   products: [
-    .library(name: "Playdate", targets: ["Playdate"]),
-    .library(name: "CPlaydate", targets: ["CPlaydate"]),
+    .library(name: "Playdate", type: .static, targets: ["Playdate"]),
+    .library(name: "CPlaydate", type: .static, targets: ["CPlaydate"]),
   ],
   targets: [
     .target(

--- a/Sources/Playdate/Sprite.swift
+++ b/Sources/Playdate/Sprite.swift
@@ -361,7 +361,11 @@ extension Sprite {
 
     let rawCollisions = spriteAPI.checkCollisions.unsafelyUnwrapped(self.pointer, goalX, goalY, &actualX, &actualY, &count)
     let collisions = UnsafeBufferPointer(start: rawCollisions, count: Int(count))
-    defer { rawCollisions?.deallocate() }
+    defer {
+      if let rawCollisions {
+        System.free(pointer: rawCollisions)
+      }
+    }
     return body(actualX, actualY, collisions)
   }
 
@@ -397,7 +401,7 @@ extension Sprite {
 
     let rawCollisions = spriteAPI.moveWithCollisions.unsafelyUnwrapped(self.pointer, goalX, goalY, &actualX, &actualY, &count)
     let collisions = UnsafeBufferPointer(start: rawCollisions, count: Int(count))
-    defer { rawCollisions?.deallocate() }
+    defer { rawCollisions.flatMap(System.free) }
     return body(actualX, actualY, collisions)
   }
 
@@ -407,7 +411,7 @@ extension Sprite {
     var count: Int32 = 0
     let rawSprites = spriteAPI.querySpritesAtPoint.unsafelyUnwrapped(x, y, &count)
     let sprites = UnsafeBufferPointer(start: rawSprites, count: Int(count))
-    defer { rawSprites?.deallocate() }
+    defer { rawSprites.flatMap(System.free) }
     return body(sprites)
   }
 
@@ -417,7 +421,7 @@ extension Sprite {
     var count: Int32 = 0
     let rawSprites = spriteAPI.querySpritesInRect.unsafelyUnwrapped(x, y, width, height, &count)
     let sprites = UnsafeBufferPointer(start: rawSprites, count: Int(count))
-    defer { rawSprites?.deallocate() }
+    defer { rawSprites.flatMap(System.free) }
     return body(sprites)
   }
 
@@ -427,7 +431,7 @@ extension Sprite {
     var count: Int32 = 0
     let rawSprites = spriteAPI.querySpritesAlongLine.unsafelyUnwrapped(x1, y1, x2, y2, &count)
     let sprites = UnsafeBufferPointer(start: rawSprites, count: Int(count))
-    defer { rawSprites?.deallocate() }
+    defer { rawSprites.flatMap(System.free) }
     return body(sprites)
   }
 
@@ -439,7 +443,7 @@ extension Sprite {
     var count: Int32 = 0
     let rawSprites = spriteAPI.querySpriteInfoAlongLine.unsafelyUnwrapped(x1, y1, x2, y2, &count)
     let sprites = UnsafeBufferPointer(start: rawSprites, count: Int(count))
-    defer { rawSprites?.deallocate() }
+    defer { rawSprites.flatMap(System.free) }
     return body(sprites)
   }
 
@@ -452,7 +456,7 @@ extension Sprite {
     var count: Int32 = 0
     let rawSprites = spriteAPI.allOverlappingSprites.unsafelyUnwrapped(&count)
     let sprites = UnsafeBufferPointer(start: rawSprites, count: Int(count))
-    defer { rawSprites?.deallocate() }
+    defer { rawSprites.flatMap(System.free) }
     return body(sprites)
   }
 }

--- a/Sources/Playdate/System.swift
+++ b/Sources/Playdate/System.swift
@@ -151,4 +151,16 @@ extension System {
   public static func clearICache() {
     systemAPI.clearICache.unsafelyUnwrapped()
   }
+  
+  /// Reallocates a pointer.
+  /// If `pointer == nil`, and `size > 0`, allocates a new pointer.
+  /// If `pointer != nil` and `size == 0` deallocates the pointer.
+  public static func realloc(pointer: UnsafeMutableRawPointer?, size: size_t) -> UnsafeMutableRawPointer? {
+    systemAPI.realloc.unsafelyUnwrapped(pointer, size)
+  }
+
+  /// Frees a pointer previously allocated with `realloc()`.
+  public static func free<T>(pointer: UnsafeMutablePointer<T>) {
+    let _ = systemAPI.realloc.unsafelyUnwrapped(pointer, 0)
+  }
 }


### PR DESCRIPTION
This is an experiment using non-embedded Swift to be able to fully debug. I've repurposed the SPM packages to build exclusively for the simulator, which now creates a dylib called `libSwiftBreak.dylib`. The companion script file, `simbuild` builds this, and then copies this to `Source/pdex.dylib` which is used to create the final `SwiftBreak.pdx` product.