### PR TITLE
Fix C Function Pointer Compatibility for Update Callback

### DIFF
--- a/Examples/SwiftBreak/Sources/Entry.swift
+++ b/Examples/SwiftBreak/Sources/Entry.swift
@@ -22,7 +22,7 @@ public func eventHandler(
 ) -> Int32 {
   initializePlaydateAPI(with: pointer)
   if event == .initialize {
-    System.setUpdateCallback(update: update, userdata: nil)
+    System.setUpdateCallback(update: { pointer in update(pointer: pointer) }, userdata: nil)
   }
   return 0
 }


### PR DESCRIPTION
This pull request addresses an issue where the `update` function could not be used as a C function pointer due to its access to the global `game` variable, which caused Swift to treat it as a closure capturing context. 

Built using toolchain `org.swift.59202403031a`.

```console
willwalker SwiftBreak > make
detected_OS is "Darwin"
Using Swift toolchain "/Library/Developer/Toolchains/swift-latest.xctoolchain/" (from /Library/Developer/Toolchains/swift-latest.xctoolchain)
mkdir -p build
mkdir -p build/dep
"/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/swiftc" -Xcc -I -Xcc /usr/local/playdate/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/include -Xcc -I -Xcc /usr/local/playdate/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/include-fixed -Xcc -I -Xcc /usr/local/playdate/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/include -O -wmo -enable-experimental-feature Embedded -enable-experimental-feature NoncopyableGenerics -Xfrontend -disable-stack-protector -Xfrontend -function-sections -swift-version 6 -Xcc -DTARGET_EXTENSION -module-cache-path build/module-cache -I /Users/willwalker/Developer/PlaydateSDK/C_API -I build/Modules -I /Users/willwalker/Developer/swift-playdate-examples/Sources/CPlaydate/include  -Xcc -mthumb -Xcc -mcpu=cortex-m7 -Xcc -mfloat-abi=hard -Xcc -mfpu=fpv5-sp-d16 -Xcc -D__FPU_USED=1 -Xcc -falign-functions=16 -Xcc -fshort-enums -target armv7em-none-none-eabi -Xfrontend -experimental-platform-c-calling-convention=arm_aapcs_vfp -module-alias Playdate=playdate_device  -c Sources/Entry.swift Sources/FixedArray.swift Sources/Game.swift Sources/Sprite+Game.swift Sources/Vector.swift -o build/game_device.o
/Users/willwalker/Developer/swift-playdate-examples/Examples/SwiftBreak/Sources/Entry.swift:25:38: error: a C function pointer can only be formed from a reference to a 'func' or a literal closure
23 |   initializePlaydateAPI(with: pointer)
24 |   if event == .initialize {
25 |     System.setUpdateCallback(update: update, userdata: nil)
   |                                      `- error: a C function pointer can only be formed from a reference to a 'func' or a literal closure
26 |   }
27 |   return 0
make: *** [build/game_device.o] Error 1
```

To resolve this, the callback setting in `eventHandler` has been modified to use a closure that directly calls the `update` function without capturing any external state:

```swift
System.setUpdateCallback(update: { pointer in update(pointer: pointer) }, userdata: nil)
```

This modification ensures that the `update` function remains compatible with the requirements for C function pointers, enabling seamless integration with the C-based Playdate SDK.