### PR TITLE
Drop experimental noncopyable generics flag

### DIFF
--- a/Examples/swift.mk
+++ b/Examples/swift.mk
@@ -41,7 +41,6 @@ SWIFT_FLAGS := \
 	$(addprefix -Xcc , $(C_FLAGS)) \
 	-O \
 	-wmo -enable-experimental-feature Embedded \
-	-enable-experimental-feature NoncopyableGenerics \
 	-Xfrontend -disable-stack-protector \
 	-Xfrontend -function-sections \
 	-swift-version 6 \


### PR DESCRIPTION
This feature made it into the release, so is no longer behind a flag.